### PR TITLE
added extra constructor to res_matcher to avoid magic numbers

### DIFF
--- a/src/modifiers.cc
+++ b/src/modifiers.cc
@@ -65,7 +65,7 @@ std::ostream& Modifiers::PrintPUSuffix(std::ostream &os) const {
 }
 
 Modifiers Modifiers::CreateStdModifiers() {
-  ResMatcher rm(6);
+  ResMatcher rm(kMatrix6);
   Modifiers ret(0, 0, 0, 0, 0, false, rm , "");
   return std::move(ret);
 }
@@ -75,7 +75,7 @@ Modifiers Modifiers::CreateMIDModifiers(
     const int insertions,
     const int deletions)
 {
-  ResMatcher rm(6);
+  ResMatcher rm(kMatrix6);
   Modifiers ret(0, mismatches, insertions, deletions, 0, false, rm, "");
   return std::move(ret);
 }

--- a/src/res_matcher.cc
+++ b/src/res_matcher.cc
@@ -28,17 +28,22 @@
 
 using namespace std;
 
-ResMatcher::ResMatcher(string matrix_file, bool comp) :
-  matrix_file_(matrix_file)
-{
-  MatrixFileToMatcher(comp);
-};
-
 ResMatcher::ResMatcher(int matrix_num) :
   matrix_num_(matrix_num)
 {
   MatrixToMatcher();
 }
+
+ResMatcher::ResMatcher(string matrix_str)
+{
+  ParseMatrix(matrix_str);
+}
+
+ResMatcher::ResMatcher(string matrix_file, bool comp) :
+  matrix_file_(matrix_file)
+{
+  MatrixFileToMatcher(comp);
+};
 
 ResMatcher::~ResMatcher()
 {}

--- a/src/res_matcher.h
+++ b/src/res_matcher.h
@@ -462,14 +462,19 @@ class ResMatcherException : public std::exception {
 class ResMatcher {
  public:
   /*
-   * Predifined matchers.
+   * Predifined matrix number.
    */
   ResMatcher(int matrix_num);
 
   /*
+   * Predifiend matrix string.
+   */
+  ResMatcher(std::string matrix_str);
+
+  /*
    * Custom complement matrix from file.
    */
-  ResMatcher(std::string matrix_file, bool comp=false);
+  ResMatcher(std::string matrix_file, bool comp);
 
   ~ResMatcher();
 

--- a/tests/test_res_matcher.cc
+++ b/tests/test_res_matcher.cc
@@ -68,7 +68,7 @@ TEST_CASE("ResMatcher::FileMatrixToMatcher", "[res_matcher]") {
   output << "T+ " << endl;
   output.close();
 
-  ResMatcher res_matcher(file);
+  ResMatcher res_matcher(file, false);
   ResMatcher res_matcher_comp(file, true);
 
   SECTION("Parse of forward matrix OK") {
@@ -91,4 +91,3 @@ TEST_CASE("ResMatcher::MatrixToMatcher all matrices can be loaded OK", "[res_mat
     REQUIRE_NOTHROW(ResMatcher res_matcher(i));
   }
 }
-


### PR DESCRIPTION
Now ResMatcher have constructors that takes a matrix number or a matrix string or a matrix file path.
