### PR TITLE
added magic option to OptParse

### DIFF
--- a/src/opt_parse.cc
+++ b/src/opt_parse.cc
@@ -121,6 +121,9 @@ void OptParse::Parse() {
       case 'V':
         options_.verbose = true;
         break;
+      case 'X':
+        options_.magic = string(optarg);
+        break;
       default:
         string msg = "Unexpected argument: ->" + string(1,(char)opt) + "<-";
         throw OptParseException(msg);

--- a/src/opt_parse.h
+++ b/src/opt_parse.h
@@ -125,6 +125,7 @@ class OptParse {
     std::string      filter;
     bool             version;
     bool             verbose;
+    std::string      magic;
   };
 
   Options options_;
@@ -193,7 +194,7 @@ class OptParse {
   /*
    * Array for holding option templates.
    */
-  const option opt_templates_[19] = {
+  const option opt_templates_[20] = {
     {"help",           no_argument,       0, 'h'},
     {"pattern",        required_argument, 0, 'p'},
     {"pattern_file",   required_argument, 0, 'P'},
@@ -212,6 +213,7 @@ class OptParse {
     {"filter" ,        required_argument, 0, 'f'},
     {"version",        no_argument,       0, 'v'},
     {"verbose",        no_argument,       0, 'V'},
+    {"magic",          required_argument, 0, 'X'},
     {0,                 0,                0,  0 }
   };
 
@@ -219,7 +221,7 @@ class OptParse {
    * String with one char options followed by : iif the option requies an
    * argument.
    */
-  const std::string opt_string_ = "hp:P:c:d:s:e:t:E:S:am:M:o:Of:vV";
+  const std::string opt_string_ = "hp:P:c:d:s:e:t:E:S:am:M:o:Of:vVX:";
 
   /*
    * Function for parsing complement option into enum OptComplement.

--- a/tests/test_opt_parse.cc
+++ b/tests/test_opt_parse.cc
@@ -25,7 +25,14 @@
 
 using namespace std;
 
-TEST_CASE("OptParse with bad option raises", "[optparse]") {
+TEST_CASE("OptParse w. bad option raises", "[optparse]") {
+  int        argc    = 4;
+  const char *argv[] = {"seqscan", "-p", "ATC", "-Z"};
+
+  REQUIRE_THROWS_AS(OptParse opt_parse(argc, (char**)argv, true), OptParseException);
+}
+
+TEST_CASE("OptParse w. missing option argument raises", "[optparse]") {
   int        argc    = 4;
   const char *argv[] = {"seqscan", "-p", "ATC", "-X"};
 
@@ -426,6 +433,26 @@ TEST_CASE("OptParse verbose", "[optparse]") {
     OptParse opt_parse(argc, (char**)argv, true);
 
     REQUIRE(opt_parse.options_.verbose);
+  }
+}
+
+TEST_CASE("OptParse magic", "[optparse]") {
+  int argc = 6;
+
+  SECTION("short option can be set OK") {
+    const char* argv[] = {"seqscan", "-p", "ATC", "-X", "foobar", "file1"};
+
+    OptParse opt_parse(argc, (char**)argv, true);
+
+    REQUIRE(opt_parse.options_.magic == "foobar");
+  }
+
+  SECTION("long option can be set OK") {
+    const char* argv[] = {"seqscan", "-p", "ATC", "--magic", "foobar", "file1"};
+
+    OptParse opt_parse(argc, (char**)argv, true);
+
+    REQUIRE(opt_parse.options_.magic == "foobar");
   }
 }
 


### PR DESCRIPTION
This is a developers only option hidden from users - to it is undocumented. It will be used for signalling at runtime which algorithm to be used:

```
seqscan -p "atcg" --magic "TNFA" seqfile.fna
```

or

```
seqscan -p "atcg" -X "TNFA" seqfile.fna
```

For the moment there is noone responding to "TNFA" but there will be.

Fixes #72

Safe to merge.
