### PR TITLE
Bug in KMP unit. Didn't respect stay_at_pos argument. Tests added.

### DIFF
--- a/src/pu/kmp_unit.cc
+++ b/src/pu/kmp_unit.cc
@@ -30,14 +30,17 @@ KMPUnit::KMPUnit(const Modifiers &modifiers, const std::string& pattern):
 bool KMPUnit::FindMatch() {
   //Inspired by http://www.sanfoundry.com/cpp-program-implement-kruth-morris-patt-algorithm-kmp/
 
-
   last_found_matches_.clear();
   last_found_index_ = 0;
 
   const int m = pattern_.length();
   int k = 0; //Pattern position
 
-  while (sequence_iterator_!=sequence_iterator_end_) {
+  auto stop_pos = sequence_iterator_end_;
+  if(stay_at_pos_ && (sequence_iterator_end_-sequence_iterator_)>m)
+    stop_pos = sequence_iterator_+m;
+
+  while (sequence_iterator_!=stop_pos) {
     if (k == -1) {
       ++sequence_iterator_;
       k = 0;
@@ -56,7 +59,6 @@ bool KMPUnit::FindMatch() {
     }
   }
   return false;
-
 }
 
 void KMPUnit::BuildTransitions()

--- a/tests/pu/test_kmp_unit.cc
+++ b/tests/pu/test_kmp_unit.cc
@@ -130,3 +130,37 @@ TEST_CASE("Test kmp sequence unit matching without fuzziness", "[kmp]") {
 
 
 
+TEST_CASE("Test KMP unit matching with stay_at_pos", "[kmp]") {
+  // Set up test pattern "AAAA/0,0,0"
+  Modifiers modifiers = Modifiers::CreateMIDModifiers(0, 0, 0);
+  unique_ptr<PatternUnit> pu(new KMPUnit(modifiers, "AAAA"));
+
+  SECTION("0 matches") {
+    string sequence = "TAAAATTT";
+    pu->Initialize(sequence.cbegin(), sequence.cend(), true);
+    REQUIRE(!pu->FindMatch());
+    REQUIRE(!pu->FindMatch());
+
+    pu->Initialize(sequence.cbegin() + 2, sequence.cend(), true);
+    REQUIRE(!pu->FindMatch());
+  }
+
+  SECTION("1 match") {
+    string sequence = "TTTAAAATTT";
+    pu->Initialize(sequence.cbegin() + 3, sequence.cend(), true);
+    REQUIRE(pu->FindMatch());
+
+    const Match &m1 = pu->GetMatch();
+    REQUIRE(m1.pos - sequence.cbegin() == 3);
+    REQUIRE(m1.len == 4);
+    REQUIRE(m1.edits == 0);
+
+    REQUIRE(!pu->FindMatch());
+  }
+
+  SECTION("Partial match extending over the end") {
+    string sequence = "TTTAAA";
+    pu->Initialize(sequence.cbegin() + 3, sequence.cend(), true);
+    REQUIRE(!pu->FindMatch());
+  }
+}


### PR DESCRIPTION
Quick manual benchmark:

```
MacBook:~/Documents/workspace-CPP/SeqScan/release $ bin/seqscan -p "ATCG{2}" ../benchmark/data/chr22.fa > /dev/null
MacBook:~/Documents/workspace-CPP/SeqScan/release $ bin/seqscan -p "ATCG{2}" ../benchmark/data/chr22.fa > /dev/null
MacBook:~/Documents/workspace-CPP/SeqScan/release $ bin/seqscan -p "ATCG{2}" ../benchmark/data/chr22.fa > /dev/null
MacBook:~/Documents/workspace-CPP/SeqScan/release $ time bin/seqscan -p "ATCG{2}" ../benchmark/data/chr22.fa
chr22   +   581913,4,0,atcg;581917,4,0,atcg 8
chr22   +   1148454,4,0,atcg;1148458,4,0,atcg   8
chr22   +   1822110,4,0,ATCG;1822114,4,0,ATCG   8
chr22   +   2972018,4,0,ATCG;2972022,4,0,ATCG   8
chr22   +   3572691,4,0,atcg;3572695,4,0,atcg   8
chr22   +   7795171,4,0,ATCG;7795175,4,0,ATCG   8
chr22   +   7832977,4,0,atcg;7832981,4,0,atcg   8
chr22   +   9357323,4,0,atcg;9357327,4,0,atcg   8
chr22   +   9968232,4,0,ATCG;9968236,4,0,ATCG   8
chr22   +   11207830,4,0,atcg;11207834,4,0,atcg 8
chr22   +   11890957,4,0,ATCG;11890961,4,0,ATCG 8
chr22   +   13880036,4,0,ATCG;13880040,4,0,ATCG 8
chr22   +   16570692,4,0,ATCG;16570696,4,0,ATCG 8
chr22   +   20433068,4,0,atcg;20433072,4,0,atcg 8
chr22   +   21641770,4,0,ATCG;21641774,4,0,ATCG 8
chr22   +   23955855,4,0,atcg;23955859,4,0,atcg 8
chr22   +   24058318,4,0,atcg;24058322,4,0,atcg 8
chr22   +   24614215,4,0,atcg;24614219,4,0,atcg 8
chr22   +   28963710,4,0,ATCG;28963714,4,0,ATCG 8
chr22   +   30332426,4,0,ATCG;30332430,4,0,ATCG 8
chr22   +   32154173,4,0,atcg;32154177,4,0,atcg 8
chr22   +   32808723,4,0,ATCG;32808727,4,0,ATCG 8
chr22   +   33433557,4,0,ATCG;33433561,4,0,ATCG 8
chr22   +   33811023,4,0,atcg;33811027,4,0,atcg 8

real    0m1.016s
user    0m0.971s
sys 0m0.041s
MacBook:~/Documents/workspace-CPP/SeqScan/release $ bin/seqscan -p "ATCGATCG" ../benchmark/data/chr22.fa > /dev/null
MacBook:~/Documents/workspace-CPP/SeqScan/release $ bin/seqscan -p "ATCGATCG" ../benchmark/data/chr22.fa > /dev/null
MacBook:~/Documents/workspace-CPP/SeqScan/release $ bin/seqscan -p "ATCGATCG" ../benchmark/data/chr22.fa > /dev/null
MacBook:~/Documents/workspace-CPP/SeqScan/release $ time bin/seqscan -p "ATCGATCG" ../benchmark/data/chr22.fa
chr22   +   581913,8,0,atcgatcg 8
chr22   +   1148454,8,0,atcgatcg    8
chr22   +   1822110,8,0,ATCGATCG    8
chr22   +   2972018,8,0,ATCGATCG    8
chr22   +   3572691,8,0,atcgatcg    8
chr22   +   7795171,8,0,ATCGATCG    8
chr22   +   7832977,8,0,atcgatcg    8
chr22   +   9357323,8,0,atcgatcg    8
chr22   +   9968232,8,0,ATCGATCG    8
chr22   +   11207830,8,0,atcgatcg   8
chr22   +   11890957,8,0,ATCGATCG   8
chr22   +   13880036,8,0,ATCGATCG   8
chr22   +   16570692,8,0,ATCGATCG   8
chr22   +   20433068,8,0,atcgatcg   8
chr22   +   21641770,8,0,ATCGATCG   8
chr22   +   23955855,8,0,atcgatcg   8
chr22   +   24058318,8,0,atcgatcg   8
chr22   +   24614215,8,0,atcgatcg   8
chr22   +   28963710,8,0,ATCGATCG   8
chr22   +   30332426,8,0,ATCGATCG   8
chr22   +   32154173,8,0,atcgatcg   8
chr22   +   32808723,8,0,ATCGATCG   8
chr22   +   33433557,8,0,ATCGATCG   8
chr22   +   33811023,8,0,atcgatcg   8

real    0m1.012s
user    0m0.968s
sys 0m0.040s
```

Conclusion: Repeats of exact strings now works and is just as fast as expanding the string.
